### PR TITLE
Remove Newconfig() as doing &Config{} appears good enough

### DIFF
--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -95,8 +95,15 @@ func main() {
 
 	// TODO: pass the config as arguments to the test binaries.
 	// --elopio - 2015-07-15
-	cfg := config.NewConfig(
-		config.DefaultFileName, *imgRelease, *imgChannel, remoteTestbed, *update, *rollback, *useSnappyFromBranch)
+	cfg := &config.Config{
+		FileName:      config.DefaultFileName,
+		Release:       *imgRelease,
+		Channel:       *imgChannel,
+		RemoteTestbed: remoteTestbed,
+		Update:        *update,
+		Rollback:      *rollback,
+		FromBranch:    *useSnappyFromBranch,
+	}
 	cfg.Write()
 
 	rootPath := testutils.RootPath()

--- a/integration-tests/testutils/config/config.go
+++ b/integration-tests/testutils/config/config.go
@@ -40,15 +40,6 @@ type Config struct {
 	FromBranch    bool
 }
 
-// NewConfig is the Config constructor
-func NewConfig(fileName, release, channel string, remoteTestbed, update, rollback, fromBranch bool) *Config {
-	return &Config{
-		FileName: fileName, Release: release, Channel: channel,
-		RemoteTestbed: remoteTestbed, Update: update, Rollback: rollback,
-		FromBranch: fromBranch,
-	}
-}
-
 // Write writes the config to a file that will be copied to the test bed.
 func (cfg Config) Write() {
 	encoded, err := json.Marshal(cfg)

--- a/integration-tests/testutils/config/config_test.go
+++ b/integration-tests/testutils/config/config_test.go
@@ -45,10 +45,10 @@ func testConfigFileName(c *check.C) string {
 }
 
 func testConfigStruct(fileName string) *Config {
-	return NewConfig(
+	return &Config{
 		fileName,
 		"testrelease", "testchannel",
-		true, true, true, true)
+		true, true, true, true}
 }
 func testConfigContents(fileName string) string {
 	return `{` +
@@ -110,7 +110,7 @@ func (s *ConfigSuite) TestReadConfigLocalTestBed(c *check.C) {
 
 	cfg, err := ReadConfig(configFileName)
 
-	testConfigStruct := NewConfig(configFileName, "testrelease", "testchannel", false, true, true, true)
+	testConfigStruct := &Config{configFileName, "testrelease", "testchannel", false, true, true, true}
 
 	c.Assert(err, check.IsNil, check.Commentf("Error reading config: %v", err))
 	c.Assert(cfg, check.DeepEquals, testConfigStruct)


### PR DESCRIPTION
It seems like NewConfig(foo, bar, false, true, false) is
harder to read than &Config{FileName: foo, Release: bar,
RemoteTestbed: false,...} so it seems like a win to use
the struct directly.
